### PR TITLE
Added implementation for IE7 & 8.

### DIFF
--- a/matchMedia.js
+++ b/matchMedia.js
@@ -2,8 +2,7 @@
 
 window.matchMedia = window.matchMedia || (function(doc, undefined){
 
-  var bool,
-      docElem  = doc.documentElement,
+  var docElem  = doc.documentElement,
       refNode  = docElem.firstElementChild || docElem.firstChild,
       // fakeBody required for <FF4 when executed in <head>
       fakeBody = doc.createElement('body'),
@@ -14,17 +13,67 @@ window.matchMedia = window.matchMedia || (function(doc, undefined){
   fakeBody.style.background = "none";
   fakeBody.appendChild(div);
 
-  return function(q){
-
-    div.innerHTML = '&shy;<style media="'+q+'"> #mq-test-1 { width: 42px; }</style>';
-
-    docElem.insertBefore(fakeBody, refNode);
+  var mqRun = function ( mq ) {
+    div.innerHTML = '&shy;<style media="' + mq + '"> #mq-test-1 { width: 42px; }</style>';
+    docElem.insertBefore( fakeBody, refNode );
     bool = div.offsetWidth === 42;
-    docElem.removeChild(fakeBody);
+    docElem.removeChild( fakeBody );
+    
+    return { matches: bool, media: mq };
+  },
+  
+  getEmValue = function () {
+    var ret,
+        body = docElem.body,
+        fakeUsed = false;
 
-    return { matches: bool, media: q };
+    div.style.cssText = "position:absolute;font-size:1em;width:1em";
+
+    if( !body ) {
+      body = fakeUsed = doc.createElement( "body" );
+      body.style.background = "none";
+    }
+
+    body.appendChild( div );
+
+    docElem.insertBefore( body, docElem.firstChild );
+
+    if( fakeUsed ) {
+      docElem.removeChild( body );
+    } else {
+      body.removeChild( div );
+    }
+    
+    //also update eminpx before returning
+    ret = eminpx = parseFloat( div.offsetWidth );
+
+    return ret;
+  },
+  
+  //cached container for 1em value, populated the first time it's needed 
+  eminpx,
+  
+  // verify that we have support for a simple media query
+  mqSupport = mqRun( '(min-width: 0px)' ).matches;
+
+  return function ( mq ) {
+    if( mqSupport ) {
+      return mqRun( mq );
+    } else {
+      var min = mq.match( /\(min\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
+          max = mq.match( /\(max\-width:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/ ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
+          minnull = min === null,
+          maxnull = max === null,
+          currWidth = doc.body.offsetWidth,
+          em = 'em';
+      
+      if( !!min ) { min = parseFloat( min ) * ( min.indexOf( em ) > -1 ? ( eminpx || getEmValue() ) : 1 ); }
+      if( !!max ) { max = parseFloat( max ) * ( max.indexOf( em ) > -1 ? ( eminpx || getEmValue() ) : 1 ); }
+      
+      bool = ( !minnull || !maxnull ) && ( minnull || currWidth >= min ) && ( maxnull || currWidth <= max );
+
+      return { matches: bool, media: mq };
+    }
   };
 
-}(document));
-
-
+}( document ));


### PR DESCRIPTION
- Test for a simple media query
- If the test passes, do as we used to do.
- If the test fails, use the secret stolen codez from respond.js.

I dropped this in my application, hit reload—picturefill suddenly works.

Then :heart:'s started flying around the room or something.  
