### PR TITLE
External extension for addListener and removeListener support

### DIFF
--- a/matchMedia.addListener.js
+++ b/matchMedia.addListener.js
@@ -1,0 +1,43 @@
+/*! matchMedia() polyfill addListener/removeListener extension. Author & copyright (c) 2012: Scott Jehl. Dual MIT/BSD license */
+(function(){
+	// monkeypatch unsupported addListener/removeListener with polling
+	if( !window.matchMedia( "" ).addListener ){
+		var oldMM = window.matchMedia;
+		
+		window.matchMedia = function( q ){
+			var ret = oldMM( q ),
+				listeners = [],
+				last = false,
+				timer,
+				check = function(){
+					var list = oldMM( q );
+					if( list.matches && !last ){
+						for( var i =0, il = listeners.length; i< il; i++ ){
+							listeners[ i ].call( ret, list );
+						}
+					}
+					last = list.matches;
+				};
+			
+			ret.addListener = function( cb ){
+				listeners.push( cb );
+				if( !timer ){
+					timer = setInterval( check, 1000 );
+				}
+			};
+
+			ret.removeListener = function( cb ){
+				for( var i =0, il = listeners.length; i< il; i++ ){
+					if( listeners[ i ] === cb ){
+						listeners.splice( i, 1 );
+					}
+				}
+				if( !listeners.length && timer ){
+					clearInterval( timer );
+				}
+			};
+			
+			return ret;
+		};
+	}
+}());


### PR DESCRIPTION
Curious if this might make sense as an external extension to the core polyfill. First, because not everyone will need/want it, but also because of browsers that had native MM support but no addListener support. 

Tested in Chrome, FF, etc.

Thoughts?
