### PR TITLE
IE performance fix: use currentStyle.width instead of offsetWidth

### DIFF
--- a/matchMedia.js
+++ b/matchMedia.js
@@ -18,10 +18,10 @@ window.matchMedia = window.matchMedia || (function( doc, undefined ) {
 
   return function(q){
 
-    div.innerHTML = "&shy;<style media=\"" + q + "\"> #mq-test-1 { width: 42px; }</style>";
+    div.innerHTML = "&shy;<style media=\"" + q + "\">#mq-test-1{width: 42px;}</style>";
 
     docElem.insertBefore( fakeBody, refNode );
-    bool = div.offsetWidth === 42;
+    bool = div.currentStyle ? (div.currentStyle.width === '42px') : div.offsetWidth === 42;
     docElem.removeChild( fakeBody );
 
     return {


### PR DESCRIPTION
IE performance enhancement: switched from testing on offsetWidth to currentStyle.width (if available). IE9 matchMedia queries now seem to be >10x faster (testing with a call count of ~10'000 calls/page, I use it with the picture polyfill). 
