### PR TITLE
Avoid 'invalid argument' on IE10.

### DIFF
--- a/matchMedia.addListener.js
+++ b/matchMedia.addListener.js
@@ -1,7 +1,7 @@
 /*! matchMedia() polyfill addListener/removeListener extension. Author & copyright (c) 2012: Scott Jehl. Dual MIT/BSD license */
 (function(){
 	// monkeypatch unsupported addListener/removeListener with polling
-	if( !window.matchMedia( "" ).addListener ){
+	if( !window.matchMedia("only screen").addListener ){
 		var oldMM = window.matchMedia;
 		
 		window.matchMedia = function( q ){


### PR DESCRIPTION
To avoid error on IE10 we should pass a valid media query

Regards,
Aurélien
