### PR TITLE
Update matchMedia polyfill to not break on IE10

### DIFF
--- a/matchMedia.addListener.js
+++ b/matchMedia.addListener.js
@@ -1,7 +1,7 @@
 /*! matchMedia() polyfill addListener/removeListener extension. Author & copyright (c) 2012: Scott Jehl. Dual MIT/BSD license */
 (function(){
 	// monkeypatch unsupported addListener/removeListener with polling
-	if( !window.matchMedia( "" ).addListener ){
+	if( !window.matchMedia( "()" ).addListener ){
 		var oldMM = window.matchMedia;
 		
 		window.matchMedia = function( q ){


### PR DESCRIPTION
native matchMedia on IE10 does not like query with empty string. String with parens seems to fix it.
