### PR TITLE
Rewrite of addListener to use window.resize rather than setInterval

### DIFF
--- a/matchMedia.addListener.js
+++ b/matchMedia.addListener.js
@@ -1,73 +1,75 @@
 /*! matchMedia() polyfill addListener/removeListener extension. Author & copyright (c) 2012: Scott Jehl. Dual MIT/BSD license */
 (function(){
-    // monkeypatch unsupported addListener/removeListener
-    if (window.matchMedia && !window.matchMedia('all').addListener){
-        var localMatchMedia = window.matchMedia,
-            hasMediaQueries = localMatchMedia('only all').matches,
-            isListening     = false,
-            timeoutID       = 0,    // setTimeout for debouncing 'handleChange'
-            queries         = [],   // Contains each 'mql' and associated 'listeners' if 'addListener' is used
-            handleChange    = function(evt) {
-                // Debounce
-                clearTimeout(timeoutID);
+    // Bail out for browsers that have addListener support
+    if (window.matchMedia && window.matchMedia('all').addListener) {
+        return false;
+    }
 
-                timeoutID = setTimeout(function() {
-                    for (var i = 0, il = queries.length; i < il; i++) {
-                        var mql         = queries[i].mql,
-                            listeners   = queries[i].listeners || [],
-                            matches     = localMatchMedia(mql.media).matches;
+    var localMatchMedia = window.matchMedia,
+        hasMediaQueries = localMatchMedia('only all').matches,
+        isListening     = false,
+        timeoutID       = 0,    // setTimeout for debouncing 'handleChange'
+        queries         = [],   // Contains each 'mql' and associated 'listeners' if 'addListener' is used
+        handleChange    = function(evt) {
+            // Debounce
+            clearTimeout(timeoutID);
 
-                        // Update mql.matches value and call listeners
-                        // Fire listeners only if transitioning to or from matched state
-                        if (matches !== mql.matches) {
-                            mql.matches = matches;
+            timeoutID = setTimeout(function() {
+                for (var i = 0, il = queries.length; i < il; i++) {
+                    var mql         = queries[i].mql,
+                        listeners   = queries[i].listeners || [],
+                        matches     = localMatchMedia(mql.media).matches;
 
-                            for (var j = 0, jl = listeners.length; j < jl; j++) {
-                                listeners[j].call(window, mql);
-                            }
+                    // Update mql.matches value and call listeners
+                    // Fire listeners only if transitioning to or from matched state
+                    if (matches !== mql.matches) {
+                        mql.matches = matches;
+
+                        for (var j = 0, jl = listeners.length; j < jl; j++) {
+                            listeners[j].call(window, mql);
                         }
                     }
-                }, 30);
-            };
-
-        window.matchMedia = function(media) {
-            var mql         = localMatchMedia(media),
-                listeners   = [],
-                index       = 0;
-
-            mql.addListener = function(listener) {
-                // Changes would not occur to css media type so return now (Affects IE <= 8)
-                if (!hasMediaQueries) {
-                    return;
                 }
-
-                // Set up 'resize' listener for browsers that support CSS3 media queries (Not for IE <= 8)
-                // There should only ever be 1 resize listener running for performance
-                if (!isListening) {
-                    isListening = true;
-                    window.addEventListener('resize', handleChange, true);
-                }
-
-                // Push object only if it has not been pushed already
-                if (index === 0) {
-                    index = queries.push({
-                        mql         : mql,
-                        listeners   : listeners
-                    });
-                }
-
-                listeners.push(listener);
-            };
-
-            mql.removeListener = function(listener) {
-                for (var i = 0, il = listeners.length; i < il; i++){
-                    if (listeners[i] === listener){
-                        listeners.splice(i, 1);
-                    }
-                }
-            };
-
-            return mql;
+            }, 30);
         };
-    }
+
+    window.matchMedia = function(media) {
+        var mql         = localMatchMedia(media),
+            listeners   = [],
+            index       = 0;
+
+        mql.addListener = function(listener) {
+            // Changes would not occur to css media type so return now (Affects IE <= 8)
+            if (!hasMediaQueries) {
+                return;
+            }
+
+            // Set up 'resize' listener for browsers that support CSS3 media queries (Not for IE <= 8)
+            // There should only ever be 1 resize listener running for performance
+            if (!isListening) {
+                isListening = true;
+                window.addEventListener('resize', handleChange, true);
+            }
+
+            // Push object only if it has not been pushed already
+            if (index === 0) {
+                index = queries.push({
+                    mql         : mql,
+                    listeners   : listeners
+                });
+            }
+
+            listeners.push(listener);
+        };
+
+        mql.removeListener = function(listener) {
+            for (var i = 0, il = listeners.length; i < il; i++){
+                if (listeners[i] === listener){
+                    listeners.splice(i, 1);
+                }
+            }
+        };
+
+        return mql;
+    };
 }());


### PR DESCRIPTION
This should provide good performance over current version because tests will only run on resize of the window. Even though this may not cover all cases, we're at least reacting to a known change in the device. Only 1 resize listener is created again for performance reasons and only for browsers that support CSS3 media queries. To do this, I save the resulting object(MediaQueryList) and its listeners to an array that get looped over on resize. This is pretty close to 100 bytes larger than the current version gzipped, so keep that in mind when reviewing. I'm not sure if there is any room for size optimization.

I'd love to hear your thoughts on this approach and see if we can do any better.
