### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "author": "Scott Jehl",
   "name": "matchMedia",
   "description": "matchMedia polyfill for testing media queries in JS",
-  "version": "0.2.0",
   "homepage": "http://github.com/paulirish/matchMedia.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property