### PR TITLE
fixing "Firefox 6" broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 * **Authors**: Scott Jehl, Paul Irish, Nicholas Zakas 
 * **Spec**: [dev.w3.org/csswg/cssom-view/#dom-window-matchmedia](http://dev.w3.org/csswg/cssom-view/#dom-window-matchmedia)
-* **Native support**: Chrome [since m10](http://trac.webkit.org/changeset/72552), Firefox [since 6](https://developer.mozilla.org/en/Firefox_6_for_developers), and Safari [since 5.1](https://developer.mozilla.org/en/DOM/window.matchMedia#Browser_compatibility)
+* **Native support**: Chrome [since m10](http://trac.webkit.org/changeset/72552), Firefox [since 6](https://developer.mozilla.org/en/Firefox/Releases/6), and Safari [since 5.1](https://developer.mozilla.org/en/DOM/window.matchMedia#Browser_compatibility)
 
 ### How about resizing the browser?
 Paul Hayes [tackled this using CSS transitions and their transitionEnd event](http://www.paulrhayes.com/2011-11/use-css-transitions-to-link-media-queries-and-javascript/) 


### PR DESCRIPTION
https://developer.mozilla.org/en/Firefox_6_for_developers was returning 404, so replacing with https://developer.mozilla.org/en/Firefox/Releases/6