### PR TITLE
Add npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm](https://img.shields.io/npm/v/matchmedia-polyfill.svg)](https://npm.com/package/matchmedia-polyfill)
+
 #matchMedia() polyfill
 
 ## test whether a CSS media type or media query applies


### PR DESCRIPTION
Several matchmedia packages are available on npm. This badge contains a link to the package on npm.com allowing the user to quickly determine the right npm package to install.

Related to #66.