### PR TITLE
this resolves the URL correctly when used with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "homepage": "http://github.com/paulirish/matchMedia.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/paulirish/matchMedia.js"
+    "url": "git://github.com/paulirish/matchMedia.js.git"
   },
   "main": "./matchMedia.js"
 }


### PR DESCRIPTION
I've noticed an issue with bower when trying to fetch this repository since it tries to get
```
git://github.com/paulirish/matchMedia.js/.git
```
instead of 
```
git://github.com/paulirish/matchMedia.js.git
```