### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+bower.json


### PR DESCRIPTION
to get the test asstets and bower references out of node_modules.