### PR TITLE
Handle no script tags in document

### DIFF
--- a/matchMedia.js
+++ b/matchMedia.js
@@ -15,7 +15,11 @@ window.matchMedia || (window.matchMedia = function() {
         style.type  = 'text/css';
         style.id    = 'matchmediajs-test';
 
-        script.parentNode.insertBefore(style, script);
+        if (!script) {
+          document.head.appendChild(style);
+        } else {
+          script.parentNode.insertBefore(style, script);
+        }
 
         // 'style.currentStyle' is used by IE <= 8 and 'window.getComputedStyle' for all other browsers
         info = ('getComputedStyle' in window) && window.getComputedStyle(style, null) || style.currentStyle;


### PR DESCRIPTION
This allows us to use the polyfill when testing with [Jest](https://facebook.github.io/jest/), which uses [jsdom](https://github.com/tmpvar/jsdom) under the hood.