### PR TITLE
Fix README.md markdown header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![npm](https://img.shields.io/npm/v/matchmedia-polyfill.svg)](https://npmjs.com/package/matchmedia-polyfill)
 
-#matchMedia() polyfill
+# matchMedia() polyfill
 
 ## test whether a CSS media type or media query applies
 


### PR DESCRIPTION
GitHub changed their markdown parsing recently and it was preventing the heading from rendering properly.